### PR TITLE
remove tshock.tp.others permission

### DIFF
--- a/Vanillafier/Main.cs
+++ b/Vanillafier/Main.cs
@@ -118,7 +118,6 @@ namespace Vanillafier
             g.AddPermission("tshock.npc.summonboss");
             g.AddPermission("tshock.npc.spawnpets");
 
-            g.AddPermission("tshock.tp.others");
             g.AddPermission("tshock.tp.rod");
             g.AddPermission("tshock.tp.wormhole");
             g.AddPermission("tshock.tp.pylon");


### PR DESCRIPTION
According to https://tshock.readme.io/docs/permissions#others
`tshock.tp.others` is the permission to teleport other players.
Aka, to use the command `/tphere`, which should not be possible for a vanilla gameplay.